### PR TITLE
Fix waitlist form to submit in background

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
             <p>Join our waitlist and be among the first to experience English learning that actually works.</p>
 
             <div id="mc_embed_signup" style="max-width: 500px; margin: 0 auto;">
-                <form action="https://script.google.com/macros/s/AKfycbyWcSZtEVAh7Yndm8UAT11QhVrUIOusVOEjKnK-Esmk0KrMC4-yttBQ-obcRtaTaKyQZw/exec" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="mailchimp-form" target="_blank" novalidate>
+                <form action="https://script.google.com/macros/s/AKfycbyWcSZtEVAh7Yndm8UAT11QhVrUIOusVOEjKnK-Esmk0KrMC4-yttBQ-obcRtaTaKyQZw/exec" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="mailchimp-form" novalidate>
                     <div id="mc_embed_signup_scroll" style="display: flex; gap: 15px; flex-wrap: wrap; justify-content: center; align-items: center;">
                         <input type="email" value="" name="email" class="email-input" id="mce-EMAIL" placeholder="Enter your email address" required style="flex: 1; min-width: 250px; padding: 15px 20px; border: none; border-radius: 25px; font-size: 1rem; outline: none;">
                         <input type="submit" value="Join Waitlist" name="subscribe" id="mc-embedded-subscribe" class="cta-button" style="min-width: 150px;">

--- a/scripts.js
+++ b/scripts.js
@@ -155,13 +155,13 @@ block: 'center'
 
 // Mailchimp form handling
 document.getElementById('mc-embedded-subscribe-form').addEventListener('submit', function(e) {
+e.preventDefault();
 
 const email = document.getElementById('mce-EMAIL').value;
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 if (!emailRegex.test(email)) {
-e.preventDefault();
-document.getElementById('mce-error-response').innerHTML = 'Please enter a valid email address';
+    document.getElementById('mce-error-response').innerHTML = 'Please enter a valid email address';
 document.getElementById('mce-error-response').style.display = 'block';
 document.getElementById('mce-success-response').style.display = 'none';
 return;


### PR DESCRIPTION
## Summary
- avoid opening a new tab when joining the waitlist
- stop default form submission and submit via fetch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842a3e12608832cbfe8e1ffa62ead1c