### PR TITLE
Improve Mailchimp response message colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,21 +401,8 @@
               />
             </div>
             <div id="mce-responses" class="clear">
-              <div
-                class="response"
-                id="mce-error-response"
-                style="display: none; color: #ff6b6b; margin-top: 15px"
-              ></div>
-              <div
-                class="response"
-                id="mce-success-response"
-                style="
-                  display: none;
-                  color: #667eea;
-                  margin-top: 15px;
-                  font-weight: 600;
-                "
-              ></div>
+              <div class="response" id="mce-error-response"></div>
+              <div class="response" id="mce-success-response"></div>
             </div>
           </form>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -781,3 +781,22 @@ body {
         transform: translateX(5px);
     }
 }
+
+/* Mailchimp response messages */
+#mce-error-response, #mce-success-response {
+    display: none;
+    margin-top: 15px;
+    padding: 12px 20px;
+    border-radius: 8px;
+    font-weight: 600;
+}
+
+#mce-error-response {
+    color: #fff;
+    background-color: #e74c3c;
+}
+
+#mce-success-response {
+    color: #fff;
+    background-color: #38c172;
+}


### PR DESCRIPTION
## Summary
- simplify markup for Mailchimp success and error messages
- style response boxes with contrasting colors

## Testing
- `git diff --color --compact-summary`

------
https://chatgpt.com/codex/tasks/task_e_6842a7e83338832c95f5ab7bea9ef986