### PR TITLE
Add privacy policy and data deletion pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@
 Reinvent the Dictionary, Learn English the way real people speak, Powered by LLMs.
 
 Visit main website at [https://chillish.app]()
+
+## Policies
+- [Privacy Policy](./privacy.html)
+- [User Data Deletion](./data-deletion.html)

--- a/data-deletion.html
+++ b/data-deletion.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Data Deletion - chillish</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="header">
+    <div class="container">
+      <div class="logo">
+        <img src="header-logo.png" alt="chillish logo">
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 80px 0; max-width: 800px;">
+    <h1>User Data Deletion</h1>
+    <p>
+      If you would like to remove any personal data that chillish has stored
+      through its Facebook app, please send a request to
+      <a href="mailto:por@okproduction.co.th">por@okproduction.co.th</a>.
+      Include the email address or Facebook user ID associated with your
+      account so we can locate your information.
+    </p>
+    <p>
+      Once we receive your request, we will delete your data from our records
+      as soon as possible and confirm completion via email.
+    </p>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2025 <span class="chillish-color">chillish</span></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -452,6 +452,10 @@
         <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
           Questions? Email us at por@okproduction.co.th
         </p>
+        <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
+          <a href="privacy.html">Privacy Policy</a> |
+          <a href="data-deletion.html">User Data Deletion</a>
+        </p>
       </div>
     </footer>
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - chillish</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="header">
+    <div class="container">
+      <div class="logo">
+        <img src="header-logo.png" alt="chillish logo">
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 80px 0; max-width: 800px;">
+    <h1>Privacy Policy</h1>
+    <p>
+      chillish ("we", "us" or "our") values your privacy. This policy
+      describes how we handle information when you use our Facebook app or
+      visit our website. We may collect your email address or other details you
+      choose to provide. This information is used solely to communicate with
+      you about our products and to improve our services.
+    </p>
+    <p>
+      We do not sell or share your personal data with third parties. We take
+      reasonable steps to protect the information you provide from
+      unauthorized access.
+    </p>
+    <p>
+      If you have questions about this policy or would like to request
+      deletion of your data, please email us at
+      <a href="mailto:por@okproduction.co.th">por@okproduction.co.th</a>.
+    </p>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2025 <span class="chillish-color">chillish</span></p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple privacy policy
- add user data deletion instructions page
- link to policy pages in footer
- mention policies in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf6af8628832c9b958ddb64bc21ec