### PR TITLE
Add career page for internship opportunities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Have ideas or suggestions? [Send us your feedback](https://www.facebook.com/shar
 ## Policies
 - [Privacy Policy](./privacy.html)
 - [User Data Deletion](./data-deletion.html)
+- [Career Opportunities](./career.html)

--- a/career.html
+++ b/career.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Careers at chillish</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="header">
+    <div class="container">
+      <div class="logo">
+        <img src="header-logo.png" alt="chillish logo">
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 80px 0; max-width: 800px; text-align: center;">
+    <h1>🚀 Internship Opportunities at <span class="chillish-color">chillish</span></h1>
+    <p style="margin-top: 20px; font-size: 1.2rem;">
+      We’re a fast-growing language learning startup, and we love working with driven university students.
+      You’ll get to work on real projects, improve your skills, and learn directly from experienced devs and creators.
+      Make your resume shine!
+    </p>
+    <div style="margin-top: 30px;">
+      <a href="mailto:por@okproduction.co.th" class="cta-button">Talk with us</a>
+      <p style="margin-top: 15px; font-size: 1.1rem;">
+        or call us at <a href="tel:+66894433297">+66 89 4433 297</a>
+      </p>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2025 <span class="chillish-color">chillish</span></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@
         </p>
         <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
           <a href="privacy.html">Privacy Policy</a> |
-          <a href="data-deletion.html">User Data Deletion</a>
+          <a href="data-deletion.html">User Data Deletion</a> | <a href="career.html">Career Opportunities</a>
         </p>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- add new `career.html` page describing internship opportunities
- link career page from footer
- reference career page in README

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6e62cba4832c8dbdae168b09b580