### PR TITLE
Reuse header footer across pages

### DIFF
--- a/data-deletion.html
+++ b/data-deletion.html
@@ -7,13 +7,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="header">
-    <div class="container">
-      <div class="logo">
-        <img src="header-logo.png" alt="chillish logo">
-      </div>
-    </div>
-  </header>
+    <div id="header"></div>
 
   <main class="container" style="padding: 80px 0; max-width: 800px;">
     <h1>User Data Deletion</h1>
@@ -30,10 +24,8 @@
     </p>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <p>&copy; 2025 <span class="chillish-color">chillish</span></p>
-    </div>
-  </footer>
+    <div id="footer"></div>
+    <script src="scripts.js"></script>
+    <script src="include.js"></script>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,15 @@
+<footer class="footer">
+  <div class="container">
+    <p>&copy; 2025 <span class="chillish-color">chillish</span>. Coming soon to revolutionize language learning. ✨</p>
+    <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
+      Questions? Email us at por@okproduction.co.th
+    </p>
+    <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
+      <a href="https://www.facebook.com/share/g/19LWcw1LA9/">Send us your feedback</a>
+    </p>
+    <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
+      <a href="privacy.html">Privacy Policy</a> |
+      <a href="data-deletion.html">User Data Deletion</a>
+    </p>
+  </div>
+</footer>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,10 @@
+<header class="header">
+  <div class="container">
+    <nav class="nav">
+      <div class="logo">
+        <img src="header-logo.png" alt="chillish dictionary logo" />
+      </div>
+      <a href="#waitlist" class="cta-button pulse">Join Waitlist</a>
+    </nav>
+  </div>
+</header>

--- a/include.js
+++ b/include.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loadFragment = (id, file) => {
+    fetch(file)
+      .then(res => res.text())
+      .then(html => {
+        const container = document.getElementById(id);
+        if (container) {
+          container.innerHTML = html;
+        }
+      });
+  };
+
+  loadFragment('header', 'header.html');
+  loadFragment('footer', 'footer.html');
+});

--- a/index.html
+++ b/index.html
@@ -48,19 +48,7 @@
       <div class="floating-emoji">✨</div>
     </div>
 
-    <header class="header">
-      <div class="container">
-        <nav class="nav">
-          <div class="logo">
-            <img
-              src="header-logo.png"
-              alt="chillish dictionary logo"
-            />
-          </div>
-          <a href="#waitlist" class="cta-button pulse">Join Waitlist</a>
-        </nav>
-      </div>
-    </header>
+    <div id="header"></div>
 
     <section class="hero">
       <div class="container">
@@ -484,25 +472,9 @@
       </div>
     </section>
 
-    <footer class="footer">
-      <div class="container">
-        <p>
-          &copy; 2025 <span class="chillish-color">chillish</span>. Coming soon
-          to revolutionize language learning. ✨
-        </p>
-        <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
-          Questions? Email us at por@okproduction.co.th
-        </p>
-        <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
-          <a href="https://www.facebook.com/share/g/19LWcw1LA9/">Send us your feedback</a>
-        </p>
-        <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
-          <a href="privacy.html">Privacy Policy</a> |
-          <a href="data-deletion.html">User Data Deletion</a>
-        </p>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <script src="scripts.js"></script>
+    <script src="include.js"></script>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -7,13 +7,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="header">
-    <div class="container">
-      <div class="logo">
-        <img src="header-logo.png" alt="chillish logo">
-      </div>
-    </div>
-  </header>
+    <div id="header"></div>
 
   <main class="container" style="padding: 80px 0; max-width: 800px;">
     <h1>Privacy Policy</h1>
@@ -36,10 +30,8 @@
     </p>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <p>&copy; 2025 <span class="chillish-color">chillish</span></p>
-    </div>
-  </footer>
+    <div id="footer"></div>
+    <script src="scripts.js"></script>
+    <script src="include.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- factor header and footer out to shared files
- load header and footer via `include.js`
- update `index.html`, `privacy.html`, and `data-deletion.html` to only contain page content

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d72c429e0832c853fef434ddb5dd6