### PR TITLE
Move Product Hunt badge above copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,11 @@
 
     <footer class="footer">
       <div class="container">
+        <p style="margin-bottom: 20px;">
+          <a href="https://www.producthunt.com/products/chillish?embed=true&utm_source=badge-featured&utm_medium=badge&utm_source=badge-chillish" target="_blank">
+            <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=989030&theme=light&t=1751883031659" alt="chillish - ai multilingual dictionary. any languages. real connection | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" />
+          </a>
+        </p>
         <p>
           &copy; 2025 <span class="chillish-color">chillish</span>. Revolutionizing language learning. ✨
         </p>
@@ -406,11 +411,6 @@
         </p>
         <p style="margin-top: 10px; font-size: 0.9rem; opacity: 0.7">
           <a href="privacy.html">Privacy Policy</a> | <a href="career.html">Career Opportunities</a>
-        </p>
-        <p style="margin-top: 20px;">
-          <a href="https://www.producthunt.com/products/chillish?embed=true&utm_source=badge-featured&utm_medium=badge&utm_source=badge-chillish" target="_blank">
-            <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=989030&theme=light&t=1751883031659" alt="chillish - ai multilingual dictionary. any languages. real connection | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" />
-          </a>
         </p>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- move the Product Hunt embed above the copyright notice in the footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ba4d44104832c946778657d06de7c