### PR TITLE
Add SEO keywords for local and native speech

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="chillish is a free AI Global Multilingual dictionary supporting English, Korean, Chinese, Thai and more languages. Discover meanings, translations and real examples for any language." />
-    <meta name="keywords" content="Dictionary, Global Multilingual Dictionary, Free dictionary, English dictionary, Korea dictionary, Chinese dictionary, Thai dictionary, Japanese dictionary, German dictionary, Spanish dictionary, French dictionary, Russian dictionary, Hindi dictionary, Turkish dictionary, AI, LLM" />
+    <meta name="description" content="Wanna talk like local or talk like native? chillish is a free AI Global Multilingual dictionary supporting English, Korean, Chinese, Thai and more languages. Discover meanings, translations and real examples for any language." />
+    <meta name="keywords" content="Dictionary, Global Multilingual Dictionary, Free dictionary, English dictionary, Korea dictionary, Chinese dictionary, Thai dictionary, Japanese dictionary, German dictionary, Spanish dictionary, French dictionary, Russian dictionary, Hindi dictionary, Turkish dictionary, AI, LLM, wanna talk like local, talk like native" />
     <meta name="robots" content="index,follow" />
     <meta name="googlebot" content="index, follow">
     <meta property="og:title" content="chillish - Reinvent the Dictionary with AI" />
@@ -386,7 +386,7 @@
     <section class="final-cta">
       <div class="container">
         <h2>Ready to Sound Like a Native? 🚀</h2>
-        <p>chillish is now live! Start using it today for free.</p>
+        <p>Wanna talk like local or talk like native? chillish is now live! Start using it today for free.</p>
         <a href="https://my.chillish.app?utm_source=landing" class="cta-button" target="_blank">Open the App</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add target phrases to meta description and keywords for better SEO
- highlight local/native phrasing in final CTA text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892dfde4560832cb6d01bd97a521ed5